### PR TITLE
feat: enable non-interactive codex execution

### DIFF
--- a/backend/run_codex_pty.py
+++ b/backend/run_codex_pty.py
@@ -6,6 +6,7 @@ import sys
 import platform
 import shutil as sh
 import threading
+import signal
 from github import Github
 from dotenv import load_dotenv
 from datetime import datetime
@@ -83,22 +84,22 @@ def run_codex_with_pty(codex_path, prompt, temp_dir):
             dimensions=(30, 120)  # rows, cols
         )
 
-        # Forward user input to Codex in interactive mode
-        if not AUTO_MODE:
-            def forward_input():
-                while True:
-                    try:
-                        data = sys.stdin.read(1)
-                        if not data:
-                            break
-                        if data == '\x03':
-                            child.sendcontrol('c')
-                        else:
-                            child.send(data)
-                    except Exception:
+        # Forward user input to Codex and allow Ctrl+C passthrough
+        def forward_input():
+            while True:
+                try:
+                    data = os.read(sys.stdin.fileno(), 1)
+                    if not data:
                         break
+                    if data == b"\x03":
+                        child.sendcontrol("c")
+                    else:
+                        child.send(data.decode())
+                except Exception:
+                    break
 
-            threading.Thread(target=forward_input, daemon=True).start()
+        prev_sigint = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        threading.Thread(target=forward_input, daemon=True).start()
         
         # Set up real-time output streaming
         output_buffer = []
@@ -163,6 +164,9 @@ def run_codex_with_pty(codex_path, prompt, temp_dir):
         # Wait for process to complete
         child.close()
         exit_code = child.exitstatus
+
+        # Restore original SIGINT handler
+        signal.signal(signal.SIGINT, prev_sigint)
         
         print("-" * 60, flush=True)
         print(f"✅ Codex PTY process completed with exit code: {exit_code}", flush=True)

--- a/backend/run_codex_pty.py
+++ b/backend/run_codex_pty.py
@@ -22,7 +22,10 @@ PROMPT = sys.argv[1] if len(sys.argv) > 1 else "Write helpful backend code"
 REPO_NAME = sys.argv[2] if len(sys.argv) > 2 else "hail007/Agent-Testing"
 REPO_URL = f"https://github.com/{REPO_NAME}.git"
 TITLE = sys.argv[3] if len(sys.argv) > 3 else "Codex Todo"
-AUTO_MODE = len(sys.argv) > 4 and sys.argv[4] == "auto"
+
+# Enable non-interactive mode by default so the script can run without
+# requiring manual input. Pass "manual" as the fourth argument to disable.
+AUTO_MODE = not (len(sys.argv) > 4 and sys.argv[4] == "manual")
 
 print(f'📝 Prompt: {PROMPT}', flush=True)
 print(f'📦 Repository: {REPO_NAME}', flush=True)
@@ -113,11 +116,15 @@ def run_codex_with_pty(codex_path, prompt, temp_dir):
                             print_and_store(child.before)
                         if child.after and child.after != pexpect.EOF:
                             print_and_store(child.after)
-                        
+
                         # Handle prompts automatically in auto mode
-                        if index in [4, 5] and AUTO_MODE:  # Yes/no or enter prompts
+                        if AUTO_MODE and index in [3, 4, 5]:
+                            # Generic questions: send empty line
+                            # Yes/no prompts: answer 'y'
+                            # Press enter prompts: send newline
                             print("\n🤖 Auto-responding to prompt...", flush=True)
-                            child.sendline('y')
+                            response = '' if index in [3, 5] else 'y'
+                            child.sendline(response)
                             time.sleep(0.5)
                 
                 except pexpect.TIMEOUT:

--- a/backend/run_codex_pty.py
+++ b/backend/run_codex_pty.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import platform
 import shutil as sh
+import threading
 from github import Github
 from dotenv import load_dotenv
 from datetime import datetime
@@ -12,7 +13,8 @@ import pexpect
 import time
 
 # === Load environment variables ===
-load_dotenv()
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(os.path.join(BASE_DIR, '.env'))
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
@@ -23,9 +25,9 @@ REPO_NAME = sys.argv[2] if len(sys.argv) > 2 else "hail007/Agent-Testing"
 REPO_URL = f"https://github.com/{REPO_NAME}.git"
 TITLE = sys.argv[3] if len(sys.argv) > 3 else "Codex Todo"
 
-# Enable non-interactive mode by default so the script can run without
-# requiring manual input. Pass "manual" as the fourth argument to disable.
-AUTO_MODE = not (len(sys.argv) > 4 and sys.argv[4] == "manual")
+# Enable interactive mode by default. Pass "auto" as the fourth argument
+# to enable automatic prompt responses.
+AUTO_MODE = len(sys.argv) > 4 and sys.argv[4] == "auto"
 
 print(f'📝 Prompt: {PROMPT}', flush=True)
 print(f'📦 Repository: {REPO_NAME}', flush=True)
@@ -80,6 +82,23 @@ def run_codex_with_pty(codex_path, prompt, temp_dir):
             encoding='utf-8',
             dimensions=(30, 120)  # rows, cols
         )
+
+        # Forward user input to Codex in interactive mode
+        if not AUTO_MODE:
+            def forward_input():
+                while True:
+                    try:
+                        data = sys.stdin.read(1)
+                        if not data:
+                            break
+                        if data == '\x03':
+                            child.sendcontrol('c')
+                        else:
+                            child.send(data)
+                    except Exception:
+                        break
+
+            threading.Thread(target=forward_input, daemon=True).start()
         
         # Set up real-time output streaming
         output_buffer = []

--- a/backend/terminal_service.py
+++ b/backend/terminal_service.py
@@ -1,11 +1,12 @@
 import asyncio
-import json
 import os
-import subprocess
+import pty
+import signal
 import uuid
 from datetime import datetime
 from typing import Dict, Optional
 import logging
+from asyncio.subprocess import Process
 
 logger = logging.getLogger("harmonia_api")
 
@@ -13,8 +14,9 @@ class TerminalSession:
     def __init__(self, session_id: str, websocket):
         self.session_id = session_id
         self.websocket = websocket
-        self.process: Optional[subprocess.Popen] = None
+        self.process: Optional[Process] = None
         self.output_task: Optional[asyncio.Task] = None
+        self.master_fd: Optional[int] = None
         self.is_active = True
         self.logs = []
         
@@ -33,7 +35,7 @@ class TerminalSession:
             await self.send_message("output", "-" * 50 + "\n")
             
             # Use the PTY-enabled Codex script
-            codex_script = "run_codex_pty.py"  # Our PTY-enabled Codex script
+            codex_script = os.path.join(os.path.dirname(__file__), "run_codex_pty.py")  # PTY-enabled Codex script
             
             if not os.path.exists(codex_script):
                 await self.send_message("error", f"❌ PTY Codex script not found: {codex_script}\n")
@@ -41,7 +43,7 @@ class TerminalSession:
                 await self.send_message("output", f"📦 Install pexpect: pip install pexpect\n")
                 return
             
-            await self.send_message("output", f"📄 Using PTY Codex script: {codex_script}\n")
+            await self.send_message("output", f"📄 Using PTY Codex script: {os.path.basename(codex_script)}\n")
             
             # Prepare the command using your script's argument format
             cmd = [
@@ -58,23 +60,29 @@ class TerminalSession:
             
             await self.send_message("output", f"🔧 Command: {' '.join(cmd)}\n")
             await self.send_message("output", f"🎯 This will use PTY to properly handle Codex CLI's raw mode\n\n")
-            
-            # Start the process with proper environment
-            self.process = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                stdin=subprocess.PIPE,
-                text=True,
-                bufsize=1,  # Line buffered
-                universal_newlines=True,
-                env={
-                    **os.environ, 
-                    "PYTHONUNBUFFERED": "1",
-                    "FORCE_COLOR": "1"
-                }
+
+            # Create PTY
+            master_fd, slave_fd = pty.openpty()
+            self.master_fd = master_fd
+
+            env = {
+                **os.environ,
+                "PYTHONUNBUFFERED": "1",
+                "FORCE_COLOR": "1",
+            }
+
+            # Launch the process inside the PTY
+            self.process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                env=env,
             )
-            
+
+            # Close slave fd in parent process
+            os.close(slave_fd)
+
             # Start output reader
             self.output_task = asyncio.create_task(self.read_output())
             
@@ -85,62 +93,49 @@ class TerminalSession:
     async def read_output(self):
         """Read output from the process with real-time streaming"""
         try:
-            while self.is_active and self.process and self.process.poll() is None:
-                if self.process.stdout:
-                    # Read line by line for Codex output
-                    line = self.process.stdout.readline()
-                    if line:
-                        # Store log
-                        self.logs.append({
-                            'timestamp': datetime.now().isoformat(),
-                            'content': line
-                        })
-                        # Send to websocket immediately
-                        await self.send_message("output", line)
-                        
-                        # Also print to actual terminal for debugging
-                        print(line, end='', flush=True)
-                    else:
-                        # No output available, wait a bit
-                        await asyncio.sleep(0.1)
-                else:
-                    await asyncio.sleep(0.1)
-            
-            # Process has ended
+            loop = asyncio.get_running_loop()
+            while self.is_active and self.master_fd is not None:
+                try:
+                    data = await loop.run_in_executor(None, os.read, self.master_fd, 1024)
+                except OSError:
+                    break
+                if not data:
+                    break
+                text = data.decode(errors="ignore")
+                self.logs.append({
+                    'timestamp': datetime.now().isoformat(),
+                    'content': text
+                })
+                await self.send_message("output", text)
+                print(text, end='', flush=True)
+
             if self.process:
-                return_code = self.process.poll()
-                if return_code is not None:
-                    completion_msg = f"\n✅ Codex completed with exit code: {return_code}\n" if return_code == 0 else f"\n⚠️ Codex exited with code: {return_code}\n"
-                    await self.send_message("output", completion_msg)
-                    print(completion_msg, flush=True)  # Also print to actual terminal
-                    await self.send_message("status", "completed")
+                return_code = await self.process.wait()
+                completion_msg = (
+                    f"\n✅ Codex completed with exit code: {return_code}\n"
+                    if return_code == 0
+                    else f"\n⚠️ Codex exited with code: {return_code}\n"
+                )
+                await self.send_message("output", completion_msg)
+                print(completion_msg, flush=True)
+                await self.send_message("status", "completed")
         except Exception as e:
             error_msg = f"Error reading output: {str(e)}"
             logger.error(error_msg)
             await self.send_message("error", error_msg)
             print(f"❌ {error_msg}", flush=True)
+        finally:
+            if self.master_fd is not None:
+                os.close(self.master_fd)
+                self.master_fd = None
     
     async def send_input(self, data: str):
         """Send input to the process - handles Codex CLI input prompts"""
         try:
-            if self.process and self.process.stdin and not self.process.stdin.closed:
-                # Handle special keys
-                if data == '\r':  # Enter key
-                    self.process.stdin.write('\n')
-                    self.process.stdin.flush()
-                    # Echo newline to terminal
-                    await self.send_message("output", '\n')
-                elif data == '\u007f':  # Backspace
-                    # Don't send backspace to process, just echo to terminal
-                    await self.send_message("output", '\b \b')
-                else:
-                    # Send regular characters
-                    self.process.stdin.write(data)
-                    self.process.stdin.flush()
-                    # Echo to terminal (so user sees what they're typing)
-                    await self.send_message("output", data)
+            if self.master_fd is not None:
+                os.write(self.master_fd, data.encode())
             else:
-                await self.send_message("error", "Cannot send input - process not ready or stdin closed")
+                await self.send_message("error", "Cannot send input - PTY not ready")
         except Exception as e:
             await self.send_message("error", f"Failed to send input: {str(e)}")
             logger.error(f"Input error: {str(e)}")
@@ -161,19 +156,23 @@ class TerminalSession:
     async def stop(self):
         """Stop the session"""
         self.is_active = False
-        if self.process:
+        if self.master_fd is not None:
             try:
-                # Send interrupt signal first
-                self.process.terminate()
-                await asyncio.sleep(2)
-                
-                # Force kill if still running
-                if self.process.poll() is None:
+                os.close(self.master_fd)
+            except OSError:
+                pass
+            self.master_fd = None
+        if self.process and self.process.returncode is None:
+            try:
+                self.process.send_signal(signal.SIGINT)
+                try:
+                    await asyncio.wait_for(self.process.wait(), timeout=2)
+                except asyncio.TimeoutError:
                     self.process.kill()
-                    await asyncio.sleep(1)
+                    await self.process.wait()
             except Exception as e:
                 logger.error(f"Error stopping process: {str(e)}")
-        
+
         if self.output_task:
             self.output_task.cancel()
     

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,6 @@ function App() {
   const [selectedIssue, setSelectedIssue] = useState('');
   const [selectedRepo, setSelectedRepo] = useState('harmoniaailabs/Symptom-to-Next-Step-Advisor-Non-Diagnostic-');
   const [selectedProjectNumber, setSelectedProjectNumber] = useState<number>(1); // Default project
-  const [availableProjects, setAvailableProjects] = useState<number[]>([]);
   const [issueDescription, setIssueDescription] = useState('');
   const [originalIssueDescription, setOriginalIssueDescription] = useState('');
   const [selectedLLM, setSelectedLLM] = useState('codex');

--- a/src/App_refactored.tsx
+++ b/src/App_refactored.tsx
@@ -29,55 +29,6 @@ const mockSprints = [
   },
 ];
 
-const mockIssues = [
-  {
-    id: 345,
-    title: 'Add auth middleware',
-    assignee: 'Alice',
-    status: 'in-progress',
-    body: 'Implement authentication middleware for API routes.',
-  },
-  {
-    id: 346,
-    title: 'Fix broken PR status badge',
-    assignee: 'Bob',
-    status: 'blocked',
-    body: 'The PR status badge is not updating correctly on the dashboard.',
-  },
-];
-
-const mockAgentTasks = [
-  {
-    id: 'task1',
-    agent: 'claude',
-    description: 'Generate integration tests',
-    status: 'running',
-  },
-  {
-    id: 'task2',
-    agent: 'codex',
-    description: 'refactoring: utils module',
-    status: 'done',
-  },
-];
-
-const mockPullRequests = [
-  {
-    id: 123,
-    title: 'Add dashboard view',
-    author: 'Carol',
-    branch: 'feature/dashboard',
-    status: 'ci-passed',
-  },
-  {
-    id: 124,
-    title: 'Update agent task handler',
-    author: 'Dave',
-    branch: 'refactor/agent-tasks',
-    status: 'needs-review',
-  },
-];
-
 const mockStats = {
   total: 18,
   completed: 7,

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,9 +3,9 @@
 const API_BASE_URL = 'http://localhost:8000/api';
 
 export interface ApiIssue {
-  url: any;
-  repository: any;
-  repo: any;
+  url: string;
+  repository: string;
+  repo: string;
   id: number;
   number: number;
   title: string;
@@ -63,14 +63,27 @@ export interface ApiRepositoryBranches {
   branches: ApiBranch[];
 }
 
+export interface ApiSprintSummary {
+  current_sprint: string;
+  start_date: string;
+  end_date: string;
+  days_remaining: number;
+  sprint_goals: string;
+  total_issues: number;
+  backlog: number;
+  ready: number;
+  in_progress: number;
+  in_review: number;
+}
+
 class ApiClient {
-  private async fetchWithErrorHandling(url: string): Promise<any> {
+  private async fetchWithErrorHandling<T>(url: string): Promise<T> {
     try {
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
-      return await response.json();
+      return await response.json() as T;
     } catch (error) {
       console.error('API Error:', error);
       throw error;
@@ -90,7 +103,7 @@ class ApiClient {
       url += `?${params.toString()}`;
     }
     
-    return this.fetchWithErrorHandling(url);
+    return this.fetchWithErrorHandling<ApiIssue[]>(url);
   }
 
   async getReadyIssues(sprintName: string, projectNumber?: number): Promise<ApiIssue[]> {
@@ -98,7 +111,7 @@ class ApiClient {
     if (projectNumber) {
       url += `&project_number=${projectNumber}`;
     }
-    return this.fetchWithErrorHandling(url);
+    return this.fetchWithErrorHandling<ApiIssue[]>(url);
   }
 
   async getSprints(projectNumber?: number): Promise<ApiSprint[]> {
@@ -106,29 +119,29 @@ class ApiClient {
     if (projectNumber) {
       url += `?project_number=${projectNumber}`;
     }
-    return this.fetchWithErrorHandling(url);
+    return this.fetchWithErrorHandling<ApiSprint[]>(url);
   }
 
-  async getSprintSummary(sprintName: string, projectNumber?: number): Promise<any> {
+  async getSprintSummary(sprintName: string, projectNumber?: number): Promise<ApiSprintSummary> {
     let url = `${API_BASE_URL}/sprint-summary?sprint_name=${encodeURIComponent(sprintName)}`;
     if (projectNumber) {
       url += `&project_number=${projectNumber}`;
     }
-    return this.fetchWithErrorHandling(url);
+    return this.fetchWithErrorHandling<ApiSprintSummary>(url);
   }
 
   // Repository and project methods
   async getRepositories(): Promise<ApiRepository[]> {
-    return this.fetchWithErrorHandling(`${API_BASE_URL}/repositories`);
+    return this.fetchWithErrorHandling<ApiRepository[]>(`${API_BASE_URL}/repositories`);
   }
 
   async getProjects(): Promise<ApiProject[]> {
-    return this.fetchWithErrorHandling(`${API_BASE_URL}/projects`);
+    return this.fetchWithErrorHandling<ApiProject[]>(`${API_BASE_URL}/projects`);
   }
 
   async getRepositoryBranches(repoName: string): Promise<ApiRepositoryBranches> {
     const url = `${API_BASE_URL}/repositories/${encodeURIComponent(repoName)}/branches`;
-    return this.fetchWithErrorHandling(url);
+    return this.fetchWithErrorHandling<ApiRepositoryBranches>(url);
   }
   
   async triggerCodexGeneration(): Promise<{ message: string }> {

--- a/src/components/CodexTerminal.tsx
+++ b/src/components/CodexTerminal.tsx
@@ -4,33 +4,29 @@ import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
 
 interface CodexTerminalProps {
-  issueId?: string;
   issueTitle?: string;
   issueDescription?: string;
   repo?: string;
 }
 
-const CodexTerminal: React.FC<CodexTerminalProps> = ({ 
-  issueId, 
+const CodexTerminal: React.FC<CodexTerminalProps> = ({
   issueTitle = 'Issue',
   issueDescription = '',
   repo = 'hail007/Agent-Testing'
 }) => {
   const terminalRef = useRef<HTMLDivElement>(null);
-  const [terminal, setTerminal] = useState<Terminal | null>(null);
-  const [socket, setSocket] = useState<WebSocket | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [prompt, setPrompt] = useState(issueDescription);
   const [autoMode, setAutoMode] = useState(false);
-  const [outputBuffer, setOutputBuffer] = useState(''); // Buffer for chunked output
   const fitAddonRef = useRef<FitAddon | null>(null);
   
   // Use refs to prevent stale closures
   const socketRef = useRef<WebSocket | null>(null);
   const terminalRef2 = useRef<Terminal | null>(null);
   const isConnectedRef = useRef(false);
+  const isRunningRef = useRef(false);
 
   // Cleanup function
   const cleanup = useCallback(() => {
@@ -43,11 +39,11 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
       terminalRef2.current.dispose();
       terminalRef2.current = null;
     }
-    setSocket(null);
-    setTerminal(null);
     setIsConnected(false);
     isConnectedRef.current = false;
     setSessionId(null);
+    setIsRunning(false);
+    isRunningRef.current = false;
   }, []);
 
   // Initialize terminal and WebSocket
@@ -91,22 +87,21 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
     
     term.loadAddon(fitAddon);
     term.open(terminalRef.current);
+    term.focus();
     fitAddon.fit();
 
     // Store terminal reference
-    terminalRef2.current = term;
-    setTerminal(term);
+      terminalRef2.current = term;
 
     // Create WebSocket connection
     const ws = new WebSocket('ws://localhost:8000/ws/terminal');
     socketRef.current = ws;
-    
+
     ws.onopen = () => {
       console.log('WebSocket connected successfully');
       if (!isConnectedRef.current) { // Prevent duplicate messages
         isConnectedRef.current = true;
         setIsConnected(true);
-        setSocket(ws);
         
         term.writeln('🚀 Harmonia Codex Terminal');
         term.writeln('================================');
@@ -134,6 +129,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
           case 'status':
             if (data.data === 'completed' || data.data === 'stopped') {
               setIsRunning(false);
+              isRunningRef.current = false;
               term.writeln('\n✅ Codex task completed');
             }
             break;
@@ -141,6 +137,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
           case 'error':
             term.writeln(`\n❌ Error: ${data.message || data.data}`);
             setIsRunning(false);
+            isRunningRef.current = false;
             break;
           
           default:
@@ -157,6 +154,8 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
         term.writeln('\n❌ Connection error');
         setIsConnected(false);
         isConnectedRef.current = false;
+        setIsRunning(false);
+        isRunningRef.current = false;
       }
     };
 
@@ -167,12 +166,13 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
         setIsConnected(false);
         isConnectedRef.current = false;
         setIsRunning(false);
+        isRunningRef.current = false;
       }
     };
 
     // Handle terminal input
     term.onData((data) => {
-      if (socketRef.current?.readyState === WebSocket.OPEN && isRunning) {
+      if (socketRef.current?.readyState === WebSocket.OPEN && isRunningRef.current) {
         socketRef.current.send(JSON.stringify({
           type: 'input',
           data: data
@@ -192,7 +192,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
       window.removeEventListener('resize', handleResize);
       cleanup();
     };
-  }, [cleanup, isRunning]);
+  }, [cleanup]);
 
   // Effect with proper cleanup
   useEffect(() => {
@@ -250,6 +250,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
 
     // Send command to start REAL Codex
     setIsRunning(true);
+    isRunningRef.current = true;
     socketRef.current.send(JSON.stringify({
       type: 'start_codex',
       prompt: prompt,
@@ -265,6 +266,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
         type: 'stop'
       }));
       setIsRunning(false);
+      isRunningRef.current = false;
     }
   };
 

--- a/src/components/CodexTerminal.tsx
+++ b/src/components/CodexTerminal.tsx
@@ -197,7 +197,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
   // Effect with proper cleanup
   useEffect(() => {
     let mounted = true;
-    
+
     // Delay initialization slightly to avoid React Strict Mode issues
     const timer = setTimeout(() => {
       if (mounted) {
@@ -210,7 +210,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
       clearTimeout(timer);
       cleanup();
     };
-  }, []); // Empty dependency array
+  }, [initialize, cleanup]);
 
   // Update prompt when issueDescription changes
   useEffect(() => {
@@ -232,7 +232,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
     if (terminalRef2.current) {
       terminalRef2.current.clear();
       terminalRef2.current.writeln('🚀 Starting REAL Codex Agent...\n');
-      
+
       if (!autoMode) {
         terminalRef2.current.writeln('🎮 Interactive Mode: You can type responses when Codex asks questions');
         terminalRef2.current.writeln('💡 Tip: Follow Codex prompts and provide input as needed');
@@ -241,6 +241,9 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
         terminalRef2.current.writeln('🤖 Auto Mode: Codex will run automatically');
         terminalRef2.current.writeln('');
       }
+
+      // Ensure the terminal has focus so keystrokes are captured
+      terminalRef2.current.focus();
     }
 
     // Use the repo passed from props

--- a/src/components/IssueHelper.tsx
+++ b/src/components/IssueHelper.tsx
@@ -12,14 +12,6 @@ const IssueHelper: React.FC<IssueHelperProps> = ({ issues }) => {
   const [issueDescription, setIssueDescription] = useState('');
   const [selectedLLM, setSelectedLLM] = useState('codex');
 
-  const handleAsk = () => {
-    console.log('Asking for help with issue:', selectedIssue);
-  };
-
-  const handleCode = () => {
-    console.log('Generating code for issue:', selectedIssue);
-  };
-
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
     console.log('Saving changes:', { selectedIssue, issueDescription, selectedLLM });
@@ -77,14 +69,6 @@ const IssueHelper: React.FC<IssueHelperProps> = ({ issues }) => {
         </div>
 
         <div className="flex space-x-4">
-        {/* <button
-          type="button"
-          onClick={handleAsk}
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-        >
-          Ask
-        </button> */}
-
         <button
           type="button"
           onClick={async () => {


### PR DESCRIPTION
## Summary
- default codex PTY runner to non-interactive mode
- auto-respond to Codex CLI prompts for unattended runs

## Testing
- `python -m py_compile backend/run_codex_pty.py`
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars and react-hooks/exhaustive-deps warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68ac5c9840c08327864039d9e86367a9