### PR TITLE
Send keystrokes regardless of running state

### DIFF
--- a/src/components/CodexTerminal.tsx
+++ b/src/components/CodexTerminal.tsx
@@ -172,7 +172,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
 
     // Handle terminal input
     term.onData((data) => {
-      if (socketRef.current?.readyState === WebSocket.OPEN && isRunning) {
+      if (socketRef.current?.readyState === WebSocket.OPEN) {
         socketRef.current.send(JSON.stringify({
           type: 'input',
           data: data
@@ -192,7 +192,7 @@ const CodexTerminal: React.FC<CodexTerminalProps> = ({
       window.removeEventListener('resize', handleResize);
       cleanup();
     };
-  }, [cleanup, isRunning]);
+  }, [cleanup]);
 
   // Effect with proper cleanup
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Always forward terminal keystrokes to backend and let server handle inactive sessions
- Drop redundant `isRunning` dependency from terminal setup effect

## Testing
- `npm test` *(fails: Missing script "test" error)*
- `npm run lint` *(fails: multiple eslint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ac7bf570188327b62f8c718e9afef6